### PR TITLE
Feature/Add Dockerfile and improve README and INSTALL docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,57 @@
+bin/
+.git
+
+# Imported from C .gitignore see:
+# https://github.com/github/gitignore/blob/master/C.gitignore
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ addons:
       - libssl-dev
       - nettle-dev
       - zlib1g-dev
+      - libbz2-dev
+      - liblzma-dev
 
 install: true
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,31 +1,48 @@
-### 0.4.4
+# CHANGES
+
+## NEXT
+
+* Update to HTSlib 1.5 (for consistency across tools)
+* Update to libBigWig 0.4.2
+
+## 0.4.4
+
 * Correct parseRegionString return type. Fixes [#11](https://github.com/cancerit/cgpBigWig/issues/11).
 * Above change also fixes [#12](https://github.com/cancerit/cgpBigWig/issues/12).
 
-### 0.4.3
+## 0.4.3
+
 * Updated libBigWig to 0.3.4 - fixes #10
 
-### 0.4.2
+## 0.4.2
+
 * Modified parsing of regions to enable names with : in (i.e. GRCh38)
 
-### 0.4.1
+## 0.4.1
+
 * Updated libBigWig to 0.3.1 - fixes issue with overflow in very large zoom levels
 
-### 0.4.0
+## 0.4.0
+
 * Added detectExtremeDepth code. Replaces functionality in PCAP-core detectExtremeDepth.pl
 
-### 0.3.1
+## 0.3.1
+
 * Changes HTSlib to 1.3.2 (bringing all stack in line)
 * Changed libBigWig archive get to use release rather than commit id (actually the same but harder to tell which release it is)
 
-### 0.3.0
+## 0.3.0
+
 * Changes to setup.sh to permit OSX installation
 
-### 0.2.1
+## 0.2.1
 * Corrections to logic
 
-### 0.2.0
+
+## 0.2.0
+
 * Added bedgraph to bw functionality via bg2bw
 
-### 0.1.0
+## 0.1.0
+
 * First release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing
+
+Contributions are welcome, and they are greatly appreciated! Every
+little bit helps, and credit will always be given.
+
+This project could always use more documentation, whether as part of the
+README, in docstrings, or even on the web in blog posts articles, and such.
+
+Please learn about [`semantic versioning`][semver].
+
+# Contents
+
+- [Contributing](#contributing)
+- [Contents](#contents)
+- [Development](#development)
+    - [Bug reports, Feature requests and feedback](#bug-reports-feature-requests-and-feedback)
+    - [Pull Request Guidelines](#pull-request-guidelines)
+- [Creating a New Release](#creating-a-new-release)
+
+# Development
+
+Set up for local development:
+
+1. Clone your cookiecutter-cli locally:
+
+    ```
+    git clone https://github.com/cancerit/cgpBigWig.git
+    ```
+
+2. Checkout to development branch:
+
+    ```
+    git checkout develop
+    git pull
+    ```
+
+3. Create a branch for local development:
+
+    ```
+    git checkout -b name-of-your-bugfix-or-feature
+    ```
+
+    Now you can make your changes locally.
+
+4. If you contributed a new feature, create a test in:
+
+    ```
+    cgpBigWig/c/c_tests/
+    ```
+
+5. Commit your changes and push your branch to GitHub:
+
+    ```
+    git add .
+    git commit -m "Your meaningful description"
+    git push origin name-of-your-bugfix-or-feature
+    ```
+
+6. Submit a pull request through the GitHub website.
+
+## Bug reports, Feature requests and feedback
+
+Go ahead and file an issue at https://github.com/cancerit/cgpBigWig/issues.
+
+If you are proposing a **feature**:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that code contributions are welcome :)
+
+When reporting a **bug** please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+## Pull Request Guidelines
+
+If you need some code review or feedback while you're developing the code just make the pull request.
+
+For merging, you should:
+
+1. Include passing tests.
+2. Update documentation when there's new API, functionality etc.
+
+# Creating a New Release
+
+Please follow this steps before publishing a new release:
+
+1. Update [INSTALL](INSTALL.md) and [Dockerfile](Dockerfile) if new dependencies are required.
+
+2. Publish docker image:
+
+        docker build -t cancerit/cgp-bigwig:`cat VERSION.txt` .
+        docker push cancerit/cgp-bigwig:`cat VERSION.txt`
+
+<!-- References -->
+
+[semver]: http://semver.org/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:16.04
 
 # Set maintainer labels.
 LABEL maintainer Keiran M. Raine <kr2@sanger.ac.uk>
-LABEL maintainer Juan S. Medina <medinaj@mskcc.org>
 
 # Install all dependencies in OPT.
 ENV OPT /opt/bundle
@@ -61,7 +60,3 @@ RUN \
 # https://github.com/BD2KGenomics/cgl-docker-lib
 VOLUME /data
 WORKDIR /data
-
-# Entry point set to wrapper.sh as per:
-# https://github.com/BD2KGenomics/cgl-docker-lib
-ENTRYPOINT ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,29 +22,19 @@ RUN \
     # Install system dependencies
     apt-get -yqq update --fix-missing && \
     apt-get -yqq install \
-    \
-    # For Locales, see below.
-    # cgpBigWig dependencies
-    wget \
-    locales \
-    build-essential \
-    zlib1g-dev \
-    libncurses5-dev \
-    libcurl4-gnutls-dev \
-    libssl-dev \
-    nettle-dev \
-    libgnutls-dev \
-    libtasn1-6-dev \
-    libbz2-dev \
-    liblzma-dev \
-    libp11-kit-dev && \
+        build-essential \
+        libbz2-dev \
+        libcurl4-gnutls-dev \
+        libgnutls-dev \
+        liblzma-dev \
+        libncurses5-dev \
+        libssl-dev \
+        locales \
+        nettle-dev \
+        wget \
+        zlib1g-dev \
+    && \
     apt-get clean && \
-    \
-    # build cgpBigWig.
-    cd /code && \
-    ./setup.sh $OPT && \
-    cd ~ && \
-    rm -rf /code \
     \
     # Configure default locale, see below.
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
@@ -59,6 +49,13 @@ RUN \
 # https://crosbymichael.com/dockerfile-best-practices-take-2.html
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
+
+# Install package.
+RUN \
+    cd /code && \
+    ./setup.sh $OPT && \
+    cd ~ && \
+    rm -rf /code
 
 # Set volume to data as per:
 # https://github.com/BD2KGenomics/cgl-docker-lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,70 @@
+FROM ubuntu:16.04
+
+# Set maintainer labels.
+LABEL maintainer Keiran M. Raine <kr2@sanger.ac.uk>
+LABEL maintainer Juan S. Medina <medinaj@mskcc.org>
+
+# Install all dependencies in OPT.
+ENV OPT /opt/bundle
+
+# Export bundle bin and lib to PATH and PERL5LIB.
+ENV PATH $OPT/bin:$PATH
+ENV PERL5LIB $OPT/lib/perl5:$PERL5LIB
+
+# Add repo.
+COPY . /code
+
+# Install package and dependencies.
+RUN \
+    # make dirs
+    mkdir -p $OPT/bin $OPT/etc $OPT/lib $OPT/share && \
+    \
+    # Install system dependencies
+    apt-get -yqq update --fix-missing && \
+    apt-get -yqq install \
+    \
+    # For Locales, see below.
+    # cgpBigWig dependencies
+    wget \
+    locales \
+    build-essential \
+    zlib1g-dev \
+    libncurses5-dev \
+    libcurl4-gnutls-dev \
+    libssl-dev \
+    nettle-dev \
+    libgnutls-dev \
+    libtasn1-6-dev \
+    libbz2-dev \
+    liblzma-dev \
+    libp11-kit-dev && \
+    apt-get clean && \
+    \
+    # build cgpBigWig.
+    cd /code && \
+    ./setup.sh $OPT && \
+    cd ~ && \
+    rm -rf /code \
+    \
+    # Configure default locale, see below.
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    locale-gen en_US.utf8 && \
+    /usr/sbin/update-locale LANG=en_US.UTF-8
+
+# For best interoperability, it should be UTF-8.
+# Some information about it here:
+# https://github.com/rocker-org/rocker/issues/19
+# http://jaredmarkell.com/docker-and-locales/
+# http://click.pocoo.org/5/python3/
+# https://crosbymichael.com/dockerfile-best-practices-take-2.html
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+# Set volume to data as per:
+# https://github.com/BD2KGenomics/cgl-docker-lib
+VOLUME /data
+WORKDIR /data
+
+# Entry point set to wrapper.sh as per:
+# https://github.com/BD2KGenomics/cgl-docker-lib
+ENTRYPOINT ["bash"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,35 +10,21 @@
 
 For installation to proceed you require the following packages:
 
+<!-- No need to duplicate this information -->
+* Ubuntu 16.04: see [`Dockerfile`](Dockerfile).
+
 * Ubuntu 14.04:
 
         apt-get update && \
         apt-get -y install \
             build-essential \
-            wget \
-            zlib1g-dev \
-            libncurses5-dev \
             libcurl4-gnutls-dev \
+            libgnutls-dev \
+            libncurses5-dev \
             libssl-dev \
             nettle-dev \
-            libgnutls-dev \
-            &&\
-        apt-get clean
-
-* Ubuntu 16.04:
-
-        apt-get update && \
-        apt-get -y install \
-            build-essential \
             wget \
             zlib1g-dev \
-            libncurses5-dev \
-            libcurl4-gnutls-dev \
-            libssl-dev \
-            nettle-dev \
-            libgnutls-dev \
-            libtasn1-6-dev \
-            libp11-kit-dev \
             &&\
         apt-get clean
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,7 @@ For installation to proceed you require the following packages:
         apt-get update && \
         apt-get -y install \
             build-essential \
+            wget \
             zlib1g-dev \
             libncurses5-dev \
             libcurl4-gnutls-dev \
@@ -29,6 +30,7 @@ For installation to proceed you require the following packages:
         apt-get update && \
         apt-get -y install \
             build-essential \
+            wget \
             zlib1g-dev \
             libncurses5-dev \
             libcurl4-gnutls-dev \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ setup.sh will install
 ```
 apt-get update && \
 apt-get -y install \
-build-essential zlib1g-dev libncurses5-dev libcurl4-gnutls-dev libssl-dev nettle-dev &&\
+build-essential zlib1g-dev libncurses5-dev libcurl4-gnutls-dev libssl-dev nettle-dev libbz2-dev liblzma-dev &&\
 apt-get clean
 ```
 
@@ -24,7 +24,7 @@ apt-get clean
 ```
 yum -q -y update && \
 yum -y install \
-make glibc-devel gcc patch ncurses-devel openssl-devel libcurl-devel gnutls-devel libtasn1-devel p11-kit-devel gmp-devel nettle-devel
+make glibc-devel gcc patch ncurses-devel openssl-devel libcurl-devel gnutls-devel libtasn1-devel p11-kit-devel gmp-devel nettle-devel libbz2-devel liblzma-devel
 ```
 
 **Should nettle-devel not exist**

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,18 +1,24 @@
-#Install:
+# Install
+
 `./setup.sh /install/to/here`
 
 `'/install/to/here'` is where you want the bin/lib folders to be created.
 
-setup.sh will install
+setup.sh will install:
+
 - cgpBigWig tools bwjoin, bwcat, bam2bw, bam2bwbases and bam2bedgraph
 
-#OS:
-  This distribution will only work on *NIX type systems at present.
+## OS
+  This distribution will only work on \*NIX type systems at present.
 
-#Other Software
-  For installation to proceed you require the following packages:
+## Other Software
 
-##For Ubuntu (tested with 14.04)
+For installation to proceed you require the following packages:
+
+### Ubuntu
+
+(tested with 14.04)
+
 ```
 apt-get update && \
 apt-get -y install \
@@ -20,7 +26,10 @@ build-essential zlib1g-dev libncurses5-dev libcurl4-gnutls-dev libssl-dev nettle
 apt-get clean
 ```
 
-##For Amazon Linux AMI (2016.03.3 x86_64)
+### Amazon Linux AMI
+
+(2016.03.3 x86_64)
+
 ```
 yum -q -y update && \
 yum -y install \
@@ -45,8 +54,10 @@ cd .. && \
 rm -rf nettle nettle.tar.gz
 ```
 
-##OSX
-  In order for cgpBigWig to install you may need the following packages installed
+### OSX
+
+In order for cgpBigWig to install you may need the following packages installed
+
 ```
 brew install gnutls
 # fixes gnutls include

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,63 +1,77 @@
-#Install:
-`./setup.sh /install/to/here`
+# Installation
 
-`'/install/to/here'` is where you want the bin/lib folders to be created.
+    ./setup.sh /path/to/installation
 
-setup.sh will install
-- cgpBigWig tools bwjoin, bwcat, bam2bw, bam2bwbases and bam2bedgraph
+`/path/to/installation` is where you want the `bin`, `lib` folders to be created. The following tools will be installed: `cgpBigWig`, `bwjoin`, `bwcat`, `bam2bw`, `bam2bwbases` and `bam2bedgraph`.
 
-#OS:
-  This distribution will only work on *NIX type systems at present.
+⚠️ *This distribution will only works on `*NIX` type systems.*
 
-#Other Software
-  For installation to proceed you require the following packages:
+# System Dependencies
 
-##For Ubuntu (tested with 14.04)
-```
-apt-get update && \
-apt-get -y install \
-build-essential zlib1g-dev libncurses5-dev libcurl4-gnutls-dev libssl-dev nettle-dev &&\
-apt-get clean
-```
+For installation to proceed you require the following packages:
 
-##For Amazon Linux AMI (2016.03.3 x86_64)
-```
-yum -q -y update && \
-yum -y install \
-make glibc-devel gcc patch ncurses-devel openssl-devel libcurl-devel gnutls-devel libtasn1-devel p11-kit-devel gmp-devel nettle-devel
-```
+* Ubuntu 14.04:
 
-**Should nettle-devel not exist**
-Use the following
+        apt-get update && \
+        apt-get -y install \
+            build-essential \
+            zlib1g-dev \
+            libncurses5-dev \
+            libcurl4-gnutls-dev \
+            libssl-dev \
+            nettle-dev \
+            libgnutls-dev \
+            &&\
+        apt-get clean
 
-```
-yum -q -y install autoconf ghostscript texinfo-tex
-wget https://git.lysator.liu.se/nettle/nettle/repository/archive.tar.gz?ref=nettle_3.2_release_20160128 -O nettle.tar.gz
-mkdir -p nettle
-tar --strip-components 1 -C nettle -zxf nettle.tar.gz
-cd nettle
-./.bootstrap
-./configure --disable-pic --disable-shared && \
-sudo make && \
-sudo make check && \
-sudo make install && \
-cd .. && \
-rm -rf nettle nettle.tar.gz
-```
+* Ubuntu 16.04:
 
-##OSX
-  In order for cgpBigWig to install you may need the following packages installed
-```
-brew install gnutls
-# fixes gnutls include
-export LIBRARY_PATH="$HOME/homebrew/lib"
-export LDFLAGS="-L$HOME/homebrew/opt/libffi/lib"
-export PKG_CONFIG_PATH="$HOME/homebrew/opt/libffi/lib/pkgconfig"
-brew install libffi
-# from https://p11-glue.freedesktop.org/doc/p11-kit/devel-building.html
-wget https://p11-glue.freedesktop.org/releases/p11-kit-0.23.2.tar.gz
-tar zxf p11-kit-0.23.2.tar.gz
-cd p11-kit-0.23.2
-./configure --prefix=$HOME/local --without-trust-paths
-make
-```
+        apt-get update && \
+        apt-get -y install \
+            build-essential \
+            zlib1g-dev \
+            libncurses5-dev \
+            libcurl4-gnutls-dev \
+            libssl-dev \
+            nettle-dev \
+            libgnutls-dev \
+            libtasn1-6-dev \
+            libp11-kit-dev \
+            &&\
+        apt-get clean
+
+* Amazon Linux AMI (2016.03.3 x86_64):
+
+        yum -q -y update && \
+        yum -y install \
+        make glibc-devel gcc patch ncurses-devel openssl-devel libcurl-devel gnutls-devel libtasn1-devel p11-kit-devel gmp-devel nettle-devel
+
+    ⚠️ Should nettle-devel not exist:
+
+        yum -q -y install autoconf ghostscript texinfo-tex
+        wget https://git.lysator.liu.se/nettle/nettle/repository/archive.tar.gz?ref=nettle_3.2_release_20160128 -O nettle.tar.gz
+        mkdir -p nettle
+        tar --strip-components 1 -C nettle -zxf nettle.tar.gz
+        cd nettle
+        ./.bootstrap
+        ./configure --disable-pic --disable-shared && \
+        sudo make && \
+        sudo make check && \
+        sudo make install && \
+        cd .. && \
+        rm -rf nettle nettle.tar.gz
+
+* OSX:
+
+        brew install gnutls
+        # fixes gnutls include
+        export LIBRARY_PATH="$HOME/homebrew/lib"
+        export LDFLAGS="-L$HOME/homebrew/opt/libffi/lib"
+        export PKG_CONFIG_PATH="$HOME/homebrew/opt/libffi/lib/pkgconfig"
+        brew install libffi
+        # from https://p11-glue.freedesktop.org/doc/p11-kit/devel-building.html
+        wget https://p11-glue.freedesktop.org/releases/p11-kit-0.23.2.tar.gz
+        tar zxf p11-kit-0.23.2.tar.gz
+        cd p11-kit-0.23.2
+        ./configure --prefix=$HOME/local --without-trust-paths
+        make

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Package of C scripts for generation of [BigWig][BigWig] coverage files.
     - [bg2bw](#bg2bw)
     - [bam2bwbases](#bam2bwbases)
     - [bam2bedgraph](#bam2bedgraph)
+- [Contributing](#contributing)
 
 # Installation
 
@@ -160,6 +161,10 @@ Other:
 -h --help      Display this usage information.
 -v --version   Prints the version number.
 ```
+
+# Contributing
+
+Contributions are welcome, and they are greatly appreciated! Check our [contributing guidelines](CONTROBUTING.md)!
 
 <!-- References -->
 [BigWig]: https://genome.ucsc.edu/goldenpath/help/bigWig.html

--- a/README.md
+++ b/README.md
@@ -1,44 +1,54 @@
-cgpBigWig
-==============
+# cgpBigWig
 
-Package of C scripts for generation of [BigWig](https://genome.ucsc.edu/goldenpath/help/bigWig.html) coverage files
+Package of C scripts for generation of [BigWig][BigWig] coverage files.
 
-| Master | Dev |
-|---|---|
-| [![Build Status](https://travis-ci.org/cancerit/cgpBigWig.svg?branch=master)](https://travis-ci.org/ICGC-TCGA-PanCancer/PCAP-core) |  [![Build Status](https://travis-ci.org/cancerit/cgpBigWig.svg?branch=develop)](https://travis-ci.org/ICGC-TCGA-PanCancer/PCAP-core) |
+| Master                                        | Develop                                         |
+| --------------------------------------------- | ----------------------------------------------- |
+| [![Master Badge][travis-master]][travis-base] | [![Develop Badge][travis-develop]][travis-base] |
 
----
+# Contents
 
-###Dependencies/Install
+- [cgpBigWig](#cgpbigwig)
+- [Contents](#contents)
+- [Installation](#installation)
+- [Programs](#programs)
+    - [bwcat](#bwcat)
+    - [bwjoin](#bwjoin)
+    - [bam2bw](#bam2bw)
+    - [bg2bw](#bg2bw)
+    - [bam2bwbases](#bam2bwbases)
+    - [bam2bedgraph](#bam2bedgraph)
 
-Some of the code included in this package has dependencies on external packages:
+# Installation
 
- * [libBigWig](https://github.com/dpryan79/libBigWig)
- * [htslib](https://github.com/samtools/htslib)
+To install this package run:
 
-Please see the respective licence for each before use.
+    setup.sh /path/to/installation
 
-Please use `setup.sh` to install the dependencies.  Please be aware that this expects basic C
-compilation libraries and tools to be available, most are listed in [`INSTALL`](INSTALL.md).
+⚠️ Be aware that this expects basic C compilation libraries and tools to be available, check the [`INSTALL`](INSTALL.md) for system specific dependencies (e.g. Ubuntu, OSX, etc.).
 
----
+`setup.sh` will install the following external dependencies:
 
-### Programs
+* [libBigWig][libBigWig]
+* [htslib][htslib]
 
-[bwcat](#bwcat) - Read the contents of a bigwig (.bw) file
+Its important that you review the respective licence for each before use.
 
-[bwjoin](#bwjoin) - Concatenate bigwig files together
+# Programs
 
-[bam2bw](#bam2bw) - Generate bigwig (.bw) coverage file from bam
+| Program                       | Description                                                               |
+| ----------------------------- | ------------------------------------------------------------------------- |
+| [bwcat](#bwcat)               | Read the contents of a bigwig (.bw) file                                  |
+| [bwjoin](#bwjoin)             | Concatenate bigwig files together                                         |
+| [bam2bw](#bam2bw)             | Generate bigwig (.bw) coverage file from bam                              |
+| [bg2bw](#bg2bw)               | Generate bigwig (.bw) coverage file from bedgraph (.bed) format           |
+| [bam2bwbases](#bam2bwbases)   | Generate bigwig (.bw) proportion file of each base at a position from bam |
+| [bam2bedgraph](#bam2bedgraph) | Generate a coverage bedgraph from bam                                     |
 
-[bg2bw](#bg2bw) - Generate bigwig (.bw) coverage file from bedgraph (.bed) format
+## bwcat
 
-[bam2bwbases](#bam2bwbases) - Generate bigwig (.bw) proportion file of each base at a position from bam
+Read the contents of a bw file.
 
-[bam2bedgraph](#bam2bedgraph) - Generate a coverage bedgraph from bam
-
-##### bwcat
-Read the contents of a bw file
 ```
 Usage: bwcat -i input-path
 
@@ -54,8 +64,10 @@ Other:
 -v --version               Prints the version number.
 ```
 
-##### bwjoin
-Concatenate bw files together
+## bwjoin
+
+Concatenate bw files together.
+
 ```
 Usage: bwjoin -f genome.fai -o output.bw
 
@@ -69,8 +81,10 @@ Other:
 -v --version   Prints the version number.
 ```
 
-##### bam2bw
-Generate bw coverage file from bam
+## bam2bw
+
+Generate bw coverage file from bam.
+
 ```
 Usage: bam2bw -i input.[b|cr]am -o output.bw
 bam2bw can be used to generate a bw file of coverage from a [cr|b]am file.
@@ -89,8 +103,10 @@ Other:
 -v  --version                                     Prints the version number.
 ```
 
-##### bg2bw
-Generate bw coverage file from bedgraph (.bed) format
+## bg2bw
+
+Generate bw coverage file from bedgraph (.bed) format.
+
 ```
 Usage: bg2bw -i input.bed -c chrom.list -o output.bw
 bg2bw can be used to generate a bw file from a bedgraph file.
@@ -104,8 +120,10 @@ Other:
 -v  --version                Prints the version number.
 ```
 
-##### bam2bwbases
-Generate bw proportion file of each base at a position from bam
+## bam2bwbases
+
+Generate bw proportion file of each base at a position from bam.
+
 ```
 Usage: bam2bwbases -i input.[b|cr]am -o output.bw
 bam2bwbases can be used to generate four bw files of per base proportions.
@@ -123,8 +141,10 @@ Other:
 -v  --version                                     Prints the version number.
 ```
 
-##### bam2bedgraph
-Generate a coverage bedgraph from bam
+## bam2bedgraph
+
+Generate a coverage bedgraph from bam.
+
 ```
 Usage: bam2bedgraph -i input.[cr|b]am -o file [-r region] [-h] [-v]
 
@@ -135,8 +155,18 @@ Create a BEDGraph file of genomic coverage. BAM file must be sorted.
 Optional:
 -r --region    Region in bam to access.
 -f --filter    Ignore reads with the filter flags [int].
+
 Other:
 -h --help      Display this usage information.
 -v --version   Prints the version number.
 ```
 
+<!-- References -->
+[BigWig]: https://genome.ucsc.edu/goldenpath/help/bigWig.html
+[libBigWig]: https://github.com/dpryan79/libBigWig
+[htslib]: https://github.com/samtools/htslib
+
+<!-- Travis -->
+[travis-base]: https://travis-ci.org/ICGC-TCGA-PanCancer/PCAP-core
+[travis-master]: https://travis-ci.org/cancerit/cgpBigWig.svg?branch=master
+[travis-develop]: https://travis-ci.org/cancerit/cgpBigWig.svg?branch=develop

--- a/c/Makefile
+++ b/c/Makefile
@@ -42,8 +42,8 @@ LFLAGS?= -L$(HTSTMP)
 # define any libraries to link into executable:
 #   if I want to link in libraries (libx.so or libx.a) I use the -llibname
 #   option, something like (this will link in libmylib.so and libm.so:
-LIBS =-lhts -lpthread -lz -lm -ldl
-LIBBWLIBS=-lBigWig -lz -lcurl -lm -lgnutls -ltasn1 -lhogweed -lnettle -lgmp -lp11-kit
+LIBS =-lhts -lpthread -lz -lbz2 -llzma -lm -ldl
+LIBBWLIBS=-lBigWig -lz -lbz2 -llzma -lcurl -lm -lgnutls -ltasn1 -lhogweed -lnettle -lgmp -lp11-kit
 
 # define the C source files
 #SRCS = ./bam_access.c ./bam_stats_output.c ./bam_stats_calcs.c

--- a/c/c_tests/test_2bam2bw.sh
+++ b/c/c_tests/test_2bam2bw.sh
@@ -142,4 +142,4 @@ then
   exit 1
 fi
 
-rm -f ../test_data/tmp.out ../test_data/expected.tmp.out
+rm -f ../test_data/tmp.out ../test_data/expected.tmp.out ../test_data/tmp.bw

--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,7 @@
 ###########################
 
 # for bamstats
-SOURCE_HTSLIB="https://github.com/samtools/htslib/releases/download/1.5/htslib-1.5.tar.bz2"
+SOURCE_HTSLIB="https://github.com/samtools/htslib/releases/download/1.7/htslib-1.7.tar.bz2"
 #libBigWig - bigwig access library
 SOURCE_LIB_BW="https://github.com/dpryan79/libBigWig/archive/0.4.2.tar.gz"
 
@@ -119,6 +119,7 @@ if [ -e $SETUP_DIR/htslib.success ]; then
   echo " previously installed ...";
 else
   echo
+  cd $SETUP_DIR
   mkdir -p htslib
   tar --strip-components 1 -C htslib -jxf htslib.tar.bz2
   cd htslib

--- a/setup.sh
+++ b/setup.sh
@@ -33,9 +33,9 @@
 ###########################
 
 # for bamstats
-SOURCE_HTSLIB="https://github.com/samtools/htslib/releases/download/1.3.2/htslib-1.3.2.tar.bz2"
+SOURCE_HTSLIB="https://github.com/samtools/htslib/releases/download/1.5/htslib-1.5.tar.bz2"
 #libBigWig - bigwig access library
-SOURCE_LIB_BW="https://github.com/dpryan79/libBigWig/archive/0.3.4.tar.gz"
+SOURCE_LIB_BW="https://github.com/dpryan79/libBigWig/archive/0.4.2.tar.gz"
 
 get_distro () {
   EXT=""


### PR DESCRIPTION
This PR is up to date with #18. I'm proposing a simple `Dockerfile` which comes in sync with https://github.com/cancerit/PCAP-core/pull/13, https://github.com/cancerit/cgpVcf/pull/23 and https://github.com/cancerit/cgpPindel/pull/57. 

* 🚀 **Features**
    - Add `Dockerfiles` with the minimum requirements necessary to build the programs.
    - Add `.dockerignore` with `C` and `Perl` ignored files.
* 📝 **Documentation changes**
    - Add `CONTRIBUTING` guidelines with `Creating a release` section.
    - Add installation documentation for ubuntu 16.04 as per #17, whilst fixing any formatting issue.
    - Add table of contents section to `README`.
* 🎨 **Style changes**
    - Add table to *programs* section.
    - Format tables in `Markdown`, happy to revert this (for me is ok since editor fixes tables formatting on save).

Please see how [README] and [INSTALL] render.

# PCAP-core

I also created this PR: https://github.com/cancerit/PCAP-core/pull/13. I think it make sense to build the docker files on top of each other (PCAP-core imports from cgpBigWig). As a result, the PCAP-core Docker file is very simple and I think that makes it easier to maintain, [check it out](https://github.com/jsmedmar/PCAP-core/blob/feature/add-dockerfile/Dockerfile). The PCAP-core PR proposes the same changes in docs.

# cgpVcf

Same with  with https://github.com/cancerit/cgpVcf/pull/23. `cgpVcf` Dockerfile imports from `PCAP-core` so that projects that depend on `cgpVcf` will have both `cgpBigWig` and `PCAP-core` already set. However, its important to note that `PCAP-core` is not a cgpVCF dependency. cgpVcf image without `PCAP-core` is 585MB, with `PCAP-core` is 871MB.

`cgpVcf` system dependencies for ubuntu 16 are:

    curl              | Missing in `pcap-core`
    build-essential
    libgnutls-dev

# cgpPindel

https://github.com/cancerit/cgpPindel/pull/57: Imports from cgpVcf container which includes cgpBigWig, PCAP-core and cgpVcf. cgpPindel system dependencies are satisfied with a successful install of cgpVcf. As such `cgpPindel`  [Dockerfile](https://github.com/jsmedmar/cgpPindel/blob/13cbf20663703914bd46400b2dbe06b255ca97ba/Dockerfile) is just a few lines.

# Other Considerations

As you noticed, each Dockerfile builds on top of each other in the dependency chain:

    cgp-bigwig
    └── pcap-core
        └── cgp-vcf
            ├── ...
            └── cgp-pindel

It would be great to have a **versioned** `cancerit/cgpDocker` repository so that other projects that are not in this dependency chain could benefit from boiler plate configurations.

    cgp-docker
    ├── cgp-bigwig
    │   └── pcap-core
    │       └── cgp-vcf
    │           ├── ...
    │           └── cgp-pindel
    ├── vaf-correct
    └── vagrent

I would recommend this as the `cgpDocker/Dockerfile`:

```
# Use ubuntu 16 across all the stack.
FROM ubuntu:16.04

# Set maintainer labels.
LABEL maintainer Keiran M. Raine <kr2@sanger.ac.uk>
LABEL maintainer ...

# Install all dependencies in OPT.
ENV OPT /opt/bundle

# Export bundle bin and lib to PATH and PERL5LIB.
ENV PATH $OPT/bin:$PATH
ENV PERL5LIB $OPT/lib/perl5:$PERL5LIB

# Install package and dependencies.
RUN \
    # Make OPT dirs.
    mkdir -p $OPT/bin $OPT/etc $OPT/lib $OPT/share && \
    \
    # Install basic system dependencies.
    apt-get -yqq update --fix-missing && \
    apt-get -yqq install \
        build-essential \
        locales \
    && \
    apt-get clean && \
    \
    # Configure default locale, see below.
    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
    locale-gen en_US.utf8 && \
    /usr/sbin/update-locale LANG=en_US.UTF-8

# For best interoperability, it should be UTF-8.
# Some information about it here:
# https://github.com/rocker-org/rocker/issues/19
# http://jaredmarkell.com/docker-and-locales/
# http://click.pocoo.org/5/python3/
# https://crosbymichael.com/dockerfile-best-practices-take-2.html
ENV LC_ALL en_US.UTF-8
ENV LANG en_US.UTF-8

# Set volume to data as per:
# https://github.com/BD2KGenomics/cgl-docker-lib
VOLUME /data
WORKDIR /data
```

[README]: https://github.com/jsmedmar/cgpBigWig/blob/install-docs-improvement/README.md
[INSTALL]: https://github.com/jsmedmar/cgpBigWig/blob/install-docs-improvement/INSTALL.md