### PR TITLE
Fix missing cast **char to const char* const*

### DIFF
--- a/c/bg2bw.c
+++ b/c/bg2bw.c
@@ -180,7 +180,7 @@ chromList_t *parse_chrom_list(char *chrom_list_file){
   }
   check(chr_count==ln_count,"Error contigs found %d != line_count %d",chr_count,ln_count);
   fclose(in);
-  cl = bwCreateChromList(contigs, lengths, chr_count);
+  cl = bwCreateChromList((const char* const*)contigs, lengths, chr_count);
   check(cl!=NULL,"Error creating ChromList.");
   return cl;
 
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]){
     num = sscanf(line,"%[^\t]\t%"SCNu32"\t%"SCNu32"\t%f\n",ctg,&start,&stop,&res);
     check(num==4,"Error parsing bed line '%s' to bw format.",line);
     check(contig_order(ctg, &prev_ctg, &prev_ctg_idx, fp->cl)==0, "Error in contig order at '%s'. chrom list should be the same order as the input bed file.",ctg);
-    chk = bwAddIntervals(fp, &ctg, &start, &stop, &res, 1);
+    chk = bwAddIntervals(fp, (const char* const*)&ctg, &start, &stop, &res, 1);
     check(chk==0,"Error encountered adding bed line '%s' to bw file: %d.",line,chk);
   }
 


### PR DESCRIPTION
Compilation using GCC 14.2 is failing:
```
bg2bw.c: In function ‘parse_chrom_list’:
bg2bw.c:183:26: error: passing argument 1 of ‘bwCreateChromList’ from incompatible pointer type [-Wincompatible-pointer-types]
  183 |   cl = bwCreateChromList(contigs, lengths, chr_count);
      |                          ^~~~~~~
      |                          |
      |                          char **
In file included from bg2bw.c:37:
libBigWig-0.4.8/bigWig.h:497:51: note: expected ‘const char * const*’ but argument is of type ‘char **’
  497 | chromList_t *bwCreateChromList(const char* const* chroms, const uint32_t *lengths, int64_t n);
      |                                ~~~~~~~~~~~~~~~~~~~^~~~~~
bg2bw.c: In function ‘main’:
bg2bw.c:230:30: error: passing argument 2 of ‘bwAddIntervals’ from incompatible pointer type [-Wincompatible-pointer-types]
  230 |     chk = bwAddIntervals(fp, &ctg, &start, &stop, &res, 1);
      |                              ^~~~
      |                              |
      |                              char **
libBigWig-0.4.8/bigWig.h:524:57: note: expected ‘const char * const*’ but argument is of type ‘char **’
  524 | int bwAddIntervals(bigWigFile_t *fp, const char* const* chrom, const uint32_t *start, const uint32_t *end, const float *values, uint32_t n);
      |                                      ~~~~~~~~~~~~~~~~~~~^~~~~
```
Reason for these errors is that contigs are `**char` but functions are expecting `const char* const*`.

This PR fixes the problem by adding the missing casts.

Thanks for commenting and/or merging.